### PR TITLE
Update ChangeBing.sh for DSM7.x

### DIFF
--- a/ChangeBing.sh
+++ b/ChangeBing.sh
@@ -10,7 +10,8 @@ wget -t 5 --no-check-certificate  $link -qO $tmpfile
 [ -s $tmpfile ]||exit
 rm -rf /usr/syno/etc/login_background*.jpg
 cp -f $tmpfile /usr/syno/etc/login_background.jpg &>/dev/null
-cp -f $tmpfile /usr/syno/etc/login_background_hd.jpg &>/dev/null
+cp -f $tmpfile /usr/syno/synoman/webman/resources/images/1x/default_login_background/dsm7_01.jpg &>/dev/null
+cp -f $tmpfile /usr/syno/synoman/webman/resources/images/2x/default_login_background/dsm7_01.jpg &>/dev/null
 title=$(echo $pic|sed 's/.\+"title":"//g'|sed 's/".\+//g')
 copyright=$(echo $pic|sed 's/.\+"copyright[:" ]\+//g'|sed 's/".\+//g')
 word=$(echo $copyright|sed 's/(.\+//g')


### PR DESCRIPTION
原命令cp -f $tmpfile /usr/syno/etc/login_background_hd.jpg &>/dev/null在DSM7.0中已失效，故通过曲线救国实现每日壁纸替换（使用下载的壁纸替换群晖的第一张默认壁纸，使用前记得备份相关文件）